### PR TITLE
several improvements for 1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,11 @@
 
 ## The project
 
-cn is a little program written in Go that helps you interacting with S3 by providing a REST S3 compatible gateway.
-This is brought by the power of Ceph and Containers. cn also comes with a set of commands to work with the S3 gateway. Available calls are:
+cn is a little program written in Go that helps you interact with the S3 API by providing a REST S3 compatible gateway. The target audience is developers building their applications on Amazon S3. It is also an exciting tool to showcase Ceph Rados Gateway S3 compatibility.
+This is brought to you by the power of Ceph and Containers. Under the hood, cn runs a Ceph container and exposes a [Rados Gateway](http://docs.ceph.com/docs/master/radosgw/). For convenience, cn also comes with a set of commands to work with the S3 gateway. Before you ask "why not using s3cmd instead?", then you will be happy to read that internally cn uses `s3cmd` and act as a wrapper around the most commonly used commands.
+Also, keep in mind that the CLI is just for convenience, and the primary use case is you developing your application directly on the S3 API.
+
+Available calls are:
 
 ```
 $  ./cn s3 -h

--- a/cmd/purge.go
+++ b/cmd/purge.go
@@ -56,6 +56,10 @@ func removeContainer(name string) {
 		panic(err)
 	}
 
+	var ImageName string
+	if DeleteAll {
+		ImageName = dockerInspect("image")
+	}
 	options := types.ContainerRemoveOptions{
 		RemoveLinks:   false,
 		RemoveVolumes: true,

--- a/cmd/s3_get.go
+++ b/cmd/s3_get.go
@@ -64,7 +64,7 @@ func S3CmdGet(cmd *cobra.Command, args []string) {
 	command := []string{"s3cmd", "get", S3CmdOpt, "s3://" + BucketObjectName, TempPath}
 	output := execContainer(ContainerName, command)
 
-	dir := dockerInspect()
+	dir := dockerInspect("bind")
 	if fileName != BucketObjectName {
 		//if _, err := os.Stat(fileName); os.Stat.Mode.IsDir(err) {
 		if info, err := os.Stat(fileName); err == nil && info.IsDir() {

--- a/cmd/s3_put.go
+++ b/cmd/s3_put.go
@@ -25,7 +25,7 @@ func CliS3CmdPut() *cobra.Command {
 func S3CmdPut(cmd *cobra.Command, args []string) {
 	notExistCheck()
 	notRunningCheck()
-	dir := dockerInspect()
+	dir := dockerInspect("bind")
 	fileName := args[0]
 	bucketName := args[1]
 	fileNameBase := path.Base(fileName)

--- a/cmd/s3_sync.go
+++ b/cmd/s3_sync.go
@@ -25,7 +25,7 @@ func S3CmdSync(cmd *cobra.Command, args []string) {
 	notRunningCheck()
 	localDir := args[0]
 	bucketName := args[1]
-	dir := dockerInspect()
+	dir := dockerInspect("bind")
 	destDir := TempPath
 
 	if localDir != dir {

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -61,7 +61,19 @@ func runContainer(cmd *cobra.Command, args []string) {
 
 	pullImage()
 
-	exposedPorts, portBindings, _ := nat.ParsePortSpecs([]string{":8000:8000"})
+	exposedPorts := nat.PortSet{
+		"8000/tcp": struct{}{},
+	}
+
+	portBindings := nat.PortMap{
+		"8000/tcp": []nat.PortBinding{
+			{
+				HostIP:   "0.0.0.0",
+				HostPort: "8000",
+			},
+		},
+	}
+
 	envs := []string{
 		"DEBUG=verbose",
 		"CEPH_DEMO_UID=" + CephNanoUID,

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -20,10 +20,13 @@ func CliStartNano() *cobra.Command {
 		Short: "Start object storage server",
 		Args:  cobra.NoArgs,
 		Run:   startNano,
-		Example: "cn start --work-dir /tmp \n" +
-			"cn start",
+		Example: "cn start \n" +
+			"cn start --work-dir /tmp \n" +
+			"cn start --image ceph/daemon:tag-stable-3.0-luminous-ubuntu-16.04",
 	}
 	cmd.Flags().StringVarP(&WorkingDirectory, "work-dir", "d", "/usr/share/ceph-nano", "Directory to work from")
+	cmd.Flags().StringVarP(&ImageName, "image", "i", "ceph/daemon", "USE AT YOUR OWN RISK. Ceph container image to use, format is 'username/image:tag'.")
+
 	return cmd
 }
 

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -78,7 +78,6 @@ func runContainer(cmd *cobra.Command, args []string) {
 		"DEBUG=verbose",
 		"CEPH_DEMO_UID=" + CephNanoUID,
 		"NETWORK_AUTO_DETECT=4",
-		"MON_IP=127.0.0.1",
 		"RGW_CIVETWEB_PORT=" + RgwPort,
 		"CEPH_DAEMON=demo"}
 

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -45,6 +45,7 @@ func startNano(cmd *cobra.Command, args []string) {
 		fmt.Println("Starting ceph-nano...")
 		startContainer()
 	} else {
+		pullImage()
 		fmt.Println("Running ceph-nano...")
 		runContainer(cmd, args)
 	}
@@ -58,8 +59,6 @@ func runContainer(cmd *cobra.Command, args []string) {
 	if err != nil {
 		panic(err)
 	}
-
-	pullImage()
 
 	exposedPorts := nat.PortSet{
 		"8000/tcp": struct{}{},

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -70,6 +70,11 @@ func runContainer(cmd *cobra.Command, args []string) {
 		"RGW_CIVETWEB_PORT=" + RgwPort,
 		"CEPH_DAEMON=demo"}
 
+	ressources := container.Resources{
+		Memory:   536870912, // 512MB
+		NanoCPUs: 1,
+	}
+
 	config := &container.Config{
 		Image:        ImageName,
 		Hostname:     ContainerName + "-faa32aebf00b",
@@ -84,9 +89,8 @@ func runContainer(cmd *cobra.Command, args []string) {
 	hostConfig := &container.HostConfig{
 		PortBindings: portBindings,
 		Binds:        []string{WorkingDirectory + ":" + TempPath},
+		Resources:    ressources,
 	}
-
-	// TODO --memory 512m
 
 	resp, err := cli.ContainerCreate(ctx, config, hostConfig, nil, ContainerName)
 	if err != nil {

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -19,7 +19,17 @@ func CliUpdateNano() *cobra.Command {
 		Short: "Update the container image",
 		Args:  cobra.NoArgs,
 		Run:   updateNano,
+		Long:  "IMPORTANT: if cn was run with --image option make sure to use the same image if you're expecting to update that image",
 	}
+	cmd.Flags().StringVarP(&ImageName, "image", "i", "ceph/daemon", "Ceph container image to use, format is 'username/image:tag'")
+
+	if status := containerStatus(false, "running"); status {
+		ImageName := dockerInspect("image")
+		if ImageName != "ceph/daemon" {
+			cmd.MarkFlagRequired("image")
+		}
+	}
+
 	return cmd
 }
 

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -294,7 +294,7 @@ func echoInfo() {
 	ips, _ := getInterfaceIPv4s()
 
 	// Get the working directory
-	dir := dockerInspect()
+	dir := dockerInspect("bind")
 
 	InfoLine :=
 		"\n" + strings.TrimSpace(string(c)) + " is the Ceph status \n" +
@@ -333,7 +333,7 @@ func getAwsKey() (string, string) {
 }
 
 // dockerInspect inspect the container Binds
-func dockerInspect() string {
+func dockerInspect(pattern string) string {
 	ctx := context.Background()
 	cli, err := client.NewEnvClient()
 	if err != nil {
@@ -343,8 +343,14 @@ func dockerInspect() string {
 	if err != nil {
 		panic(err)
 	}
-	parts := strings.Split(inspect.HostConfig.Binds[0], ":")
-	return parts[0]
+
+	if pattern == "bind" {
+		parts := strings.Split(inspect.HostConfig.Binds[0], ":")
+		return parts[0]
+	}
+	// this assumes a default that we are looking for the image name
+	parts := inspect.Config.Image
+	return parts
 }
 
 // inspectImage inspect a given image
@@ -354,6 +360,7 @@ func inspectImage() map[string]string {
 	if err != nil {
 		panic(err)
 	}
+	ImageName := dockerInspect("image")
 	i, _, err := cli.ImageInspectWithRaw(ctx, ImageName)
 	if err != nil {
 		var m map[string]string

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -232,7 +232,7 @@ func cephNanoHealth() {
 	buf.ReadFrom(out)
 	newStr := buf.String()
 	fmt.Println(newStr)
-	fmt.Println("Please open an issue at: https://github.com/ceph/ceph-container.")
+	fmt.Println("Please open an issue at: https://github.com/ceph/cn.")
 	os.Exit(1)
 }
 
@@ -272,7 +272,7 @@ func cephNanoS3Health() {
 	}
 	fmt.Println("S3 gateway is not responding. Showing S3 logs:")
 	showS3Logs()
-	fmt.Println("Please open an issue at: https://github.com/ceph/ceph-nano.")
+	fmt.Println("Please open an issue at: https://github.com/ceph/cn.")
 	os.Exit(1)
 }
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -20,8 +21,16 @@ func CliVersionNano() *cobra.Command {
 // versionNano print Ceph Nano version
 func versionNano(cmd *cobra.Command, args []string) {
 	fmt.Println("ceph-nano version " + Version)
+	if status := containerStatus(true, "exited"); status {
+		os.Exit(0)
+	}
+	if status := containerStatus(false, "running"); !status {
+		os.Exit(0)
+	}
 	if ii := inspectImage(); ii["head"] == "unknown" {
 		fmt.Println("ceph-nano container image version is unknown (no image pulled yet)")
+	} else if len(ii["head"]) == 0 {
+		fmt.Println("ceph-nano container image version is unknown (you're likely running an old image, one that doesn't have a commit label)")
 	} else {
 		fmt.Println("ceph-nano container image version " + ii["head"])
 	}


### PR DESCRIPTION
We now use 1 single CPU and 512MB for the container.

Signed-off-by: Sébastien Han <seb@redhat.com>