### PR TITLE
client: maintain a single docker client connection

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -33,7 +33,7 @@ var (
 	// ImageName is the name of the container image
 	ImageName = "ceph/daemon"
 
-	// Temporary path inside the container
+	// TempPath is the temporary path inside the container
 	TempPath = "/tmp/"
 
 	rootCmd = &cobra.Command{

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,9 +1,11 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 
+	"github.com/docker/docker/client"
 	"github.com/spf13/cobra"
 )
 
@@ -40,7 +42,24 @@ var (
 		SuggestFor: []string{"cn"},
 		//Long:
 	}
+
+	// dockerCli initializes the client connection
+	dockerCli *client.Client
+
+	// ctx opens context
+	ctx = context.Background()
 )
+
+func getDocker() *client.Client {
+	if dockerCli == nil {
+		cli, err := client.NewEnvClient()
+		if err != nil {
+			panic(err)
+		}
+		dockerCli = cli
+	}
+	return dockerCli
+}
 
 // Main is the main function calling the whole program
 func Main() {

--- a/cmd/purge.go
+++ b/cmd/purge.go
@@ -48,7 +48,6 @@ func purgeNano(cmd *cobra.Command, args []string) {
 }
 
 func removeContainer(name string) {
-	var ImageName string
 	if DeleteAll {
 		ImageName = dockerInspect("image")
 	}

--- a/cmd/purge.go
+++ b/cmd/purge.go
@@ -1,12 +1,10 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"os"
 
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/client"
 	"github.com/spf13/cobra"
 )
 
@@ -50,12 +48,6 @@ func purgeNano(cmd *cobra.Command, args []string) {
 }
 
 func removeContainer(name string) {
-	ctx := context.Background()
-	cli, err := client.NewEnvClient()
-	if err != nil {
-		panic(err)
-	}
-
 	var ImageName string
 	if DeleteAll {
 		ImageName = dockerInspect("image")
@@ -67,7 +59,7 @@ func removeContainer(name string) {
 	}
 	// we don't necessarily want to catch errors here
 	// it's not an issue if the container does not exist
-	cli.ContainerRemove(ctx, name, options)
+	getDocker().ContainerRemove(ctx, name, options)
 
 	if DeleteAll {
 		options := types.ImageRemoveOptions{
@@ -75,6 +67,6 @@ func removeContainer(name string) {
 			PruneChildren: true,
 		}
 		fmt.Println("Removing container image...")
-		cli.ImageRemove(ctx, ImageName, options)
+		getDocker().ImageRemove(ctx, ImageName, options)
 	}
 }

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -3,9 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/docker/docker/client"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 // CliRestartNano is the Cobra CLI call
@@ -21,15 +19,9 @@ func CliRestartNano() *cobra.Command {
 
 // restartNano restarts Ceph Nano
 func restartNano(cmd *cobra.Command, args []string) {
-	ctx := context.Background()
-	cli, err := client.NewEnvClient()
-	if err != nil {
-		panic(err)
-	}
-
 	notExistCheck()
 	fmt.Println("Restarting ceph-nano...")
-	if err := cli.ContainerRestart(ctx, ContainerName, nil); err != nil {
+	if err := getDocker().ContainerRestart(ctx, ContainerName, nil); err != nil {
 		panic(err)
 	}
 	echoInfo()

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -7,10 +7,8 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/client"
 	"github.com/docker/go-connections/nat"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 // CliStartNano is the Cobra CLI call
@@ -57,12 +55,6 @@ func startNano(cmd *cobra.Command, args []string) {
 
 // runContainer creates a new container when nothing exists
 func runContainer(cmd *cobra.Command, args []string) {
-	ctx := context.Background()
-	cli, err := client.NewEnvClient()
-	if err != nil {
-		panic(err)
-	}
-
 	exposedPorts := nat.PortSet{
 		"8000/tcp": struct{}{},
 	}
@@ -105,12 +97,12 @@ func runContainer(cmd *cobra.Command, args []string) {
 		Resources:    ressources,
 	}
 
-	resp, err := cli.ContainerCreate(ctx, config, hostConfig, nil, ContainerName)
+	resp, err := getDocker().ContainerCreate(ctx, config, hostConfig, nil, ContainerName)
 	if err != nil {
 		panic(err)
 	}
 
-	err = cli.ContainerStart(ctx, resp.ID, types.ContainerStartOptions{})
+	err = getDocker().ContainerStart(ctx, resp.ID, types.ContainerStartOptions{})
 	// The if removes the error:
 	//panic: runtime error: invalid memory address or nil pointer dereference
 	//[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x137a2b4]
@@ -132,13 +124,7 @@ func runContainer(cmd *cobra.Command, args []string) {
 
 // startContainer starts a container that is stopped
 func startContainer() {
-	ctx := context.Background()
-	cli, err := client.NewEnvClient()
-	if err != nil {
-		panic(err)
-	}
-
-	if err := cli.ContainerStart(ctx, ContainerName, types.ContainerStartOptions{}); err != nil {
+	if err := getDocker().ContainerStart(ctx, ContainerName, types.ContainerStartOptions{}); err != nil {
 		panic(err)
 	}
 }

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -2,9 +2,7 @@ package cmd
 
 import (
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/client"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 // CliStatusNano is the Cobra CLI call
@@ -28,16 +26,11 @@ func statusNano(cmd *cobra.Command, args []string) {
 // containerStatus checks container status
 // the parameter corresponds to the type listOptions and its entry all
 func containerStatus(allList bool, containerState string) bool {
-	cli, err := client.NewEnvClient()
-	if err != nil {
-		panic(err)
-	}
-
 	listOptions := types.ContainerListOptions{
 		All:   allList,
 		Quiet: true,
 	}
-	containers, err := cli.ContainerList(context.Background(), listOptions)
+	containers, err := getDocker().ContainerList(ctx, listOptions)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -5,9 +5,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/docker/docker/client"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 // CliStopNano is the Cobra CLI call
@@ -23,12 +21,6 @@ func CliStopNano() *cobra.Command {
 
 // stopNano stops Ceph Nano
 func stopNano(cmd *cobra.Command, args []string) {
-	ctx := context.Background()
-	cli, err := client.NewEnvClient()
-	if err != nil {
-		panic(err)
-	}
-
 	timeout := 5 * time.Second
 	if status := containerStatus(true, "exited"); status {
 		fmt.Println("ceph-nano is already stopped.")
@@ -38,7 +30,7 @@ func stopNano(cmd *cobra.Command, args []string) {
 		os.Exit(0)
 	} else {
 		fmt.Println("Stopping ceph-nano... ")
-		if err := cli.ContainerStop(ctx, ContainerName, &timeout); err != nil {
+		if err := getDocker().ContainerStop(ctx, ContainerName, &timeout); err != nil {
 			panic(err)
 		}
 	}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -1,14 +1,12 @@
 package cmd
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
 
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/client"
 	"github.com/spf13/cobra"
 )
 
@@ -35,14 +33,8 @@ func CliUpdateNano() *cobra.Command {
 
 // updateNano updates the container image
 func updateNano(cmd *cobra.Command, args []string) {
-	ctx := context.Background()
-	cli, err := client.NewEnvClient()
-	if err != nil {
-		panic(err)
-	}
-
 	if !pullImage() {
-		events, err := cli.ImagePull(ctx, ImageName, types.ImagePullOptions{})
+		events, err := getDocker().ImagePull(ctx, ImageName, types.ImagePullOptions{})
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
For each command we run, we now maintain the same connection to the
Docker API. This removes the duplication of new client access.

Signed-off-by: Sébastien Han <seb@redhat.com>