### PR TITLE
release: Adding cross-compiling targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,34 @@
-.PHONY: cn
+.PHONY: build
 
 VERSION = $(shell git describe --always --long --dirty)
 TAG = devel
 BRANCH = $(shell git rev-parse --abbrev-ref HEAD)
 
-cn: clean
-	go build -i -ldflags="-X main.version=$(VERSION) -X main.tag=$(TAG) -X main.branch=$(BRANCH)"
-	mv cn cn-$(TAG)-$(VERSION)
-	ln -sf "cn-$(TAG)-$(VERSION)" cn
+# Variables to choose cross-compile target
+GOOS:=linux
+GOARCH:=amd64
+CN_EXTENSION:=
+
+build: clean
+	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -i -ldflags="-X main.version=$(VERSION) -X main.tag=$(TAG) -X main.branch=$(BRANCH)"
+	mv cn$(CN_EXTENSION) cn-$(TAG)-$(VERSION)-$(GOOS)-$(GOARCH)$(CN_EXTENSION)
+	ln -sf "cn-$(TAG)-$(VERSION)-$(GOOS)-$(GOARCH)$(CN_EXTENSION)" cn$(CN_EXTENSION)
+
+darwin:
+	make GOOS=darwin
+
+linux:
+	make GOOS=linux
+
+windows:
+	go get github.com/inconshreveable/mousetrap
+	make GOOS=windows CN_EXTENSION=".exe"
+
+release: darwin linux windows
 
 clean:
 	rm -f cn &>/dev/null || true
+	rm -f cn.exe &>/dev/null || true
 
 clean-all: clean
 	rm -f cn-* &>/dev/null || true

--- a/release.sh
+++ b/release.sh
@@ -135,8 +135,8 @@ else
   git checkout -q $TAG || fatal "Cannot checkout tag $TAG"
 fi
 
-echo "Building binary for git tag $TAG"
-make -s TAG=$TAG || fatal "Cannot build ceph-nano !"
+echo "Building binaries for git tag $TAG"
+make -s release TAG=$TAG || fatal "Cannot build ceph-nano !"
 
 # If we did checkout the TAG, we need to return to the previous branch
 GIT_CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
@@ -156,7 +156,10 @@ echo "Uploading CHANGELOG"
 github-release upload --user $GITHUB_USER --repo $repo --tag ${TAG} --name CHANGELOG --file $CHANGELOG || fatal "Cannot upload CHANGELOG"
 rm -f $CHANGELOG
 
-echo "Uploading binary"
-github-release upload --user $GITHUB_USER --repo $repo --tag ${TAG} --name cn-$TAG --file cn || fatal "Cannot upload cn"
+echo "Uploading binaries"
+for binary in cn*$TAG*; do
+  echo "- $binary"
+  github-release upload --user $GITHUB_USER --repo $repo --tag ${TAG} --name $binary --file $binary || fatal "Cannot upload cn"
+done
 
 echo "Release can be browsed at https://github.com/$GITHUB_USER/$repo/releases/tag/$TAG"


### PR DESCRIPTION
When building a release, it's pretty convinient to build several system
targets at the same time.

This way, Linux/Mac/Windows users share the same code version by using the same build process.

This patch introduce cross-compilation targets:
- make darwin  -> to build binary for Apple
- make windows -> to build binary for Windows
- make linux   -> to build binary for Linux (default)
- make release -> build all the above

A typical output looks like:
    Does v1.1.0 the git tag to consider for builiding the CHANGELOG ? (yes / no) yes
    Building binaries for git tag 9.9.9
    Building CHANGELOG between 9.9.9 and v1.1.0
    Creating release 9.9.9
    Uploading CHANGELOG
    Uploading binaries
    - cn-9.9.9-b2aa9a6-darwin-amd64
    - cn-9.9.9-b2aa9a6-linux-amd64
    - cn-9.9.9-b2aa9a6-windows-amd64.exe

Note that currently only 64bit builds are considered.