### PR TITLE
add support for arm64 build on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,18 +21,18 @@ prepare:
 	go get github.com/spf13/cobra
 
 darwin:
-	make GOOS=darwin
-
-linux:
-	make GOOS=linux
+	make GOOS=darwin GOARCH:=amd64
 
 windows:
-	make GOOS=windows CN_EXTENSION=".exe"
+	make GOOS=windows CN_EXTENSION=".exe" GOARCH:=amd64
+
+linux-%:
+	make GOOS=linux GOARCH:=$*
 
 tests:
 	tests/functional-tests.sh
 
-release: darwin linux windows
+release: darwin windows linux-amd64 linux-arm64
 
 clean:
 	rm -f cn &>/dev/null || true


### PR DESCRIPTION
Closes: https://github.com/ceph/cn/issues/19
Signed-off-by: Sébastien Han <seb@redhat.com>