### PR TITLE
start: add support for dedicated block device

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ prepare:
 	go get github.com/spf13/cobra
 	go get github.com/jmoiron/jsonq
 	go get github.com/apcera/termtables
+	go get golang.org/x/sys/unix
 
 darwin:
 	make GOOS=darwin GOARCH:=amd64

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -92,7 +92,6 @@ func getDocker() *client.Client {
 // Main is the main function calling the whole program
 func Main(version string) {
 	cnVersion = version
-	validateEnv()
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/docker/docker/api/types"
@@ -15,6 +17,9 @@ import (
 var (
 	// PrivilegedContainer whether or not the container should run Privileged
 	PrivilegedContainer bool
+
+	// Data points to either the directory or drive to use to store Ceph's data
+	Data string
 )
 
 // CliClusterStart is the Cobra CLI call
@@ -31,6 +36,7 @@ func CliClusterStart() *cobra.Command {
 	cmd.Flags().SortFlags = false
 	cmd.Flags().StringVarP(&WorkingDirectory, "work-dir", "d", "/usr/share/ceph-nano", "Directory to work from")
 	cmd.Flags().StringVarP(&ImageName, "image", "i", "ceph/daemon", "USE AT YOUR OWN RISK. Ceph container image to use, format is 'username/image:tag'.")
+	cmd.Flags().StringVarP(&Data, "data", "b", "", "Configure Ceph Nano underlying storage with a specific directory or physical block device. Block device support only works on Linux running under 'root', only also directory might need running as 'root' if SeLinux is enabled.")
 	cmd.Flags().BoolVar(&PrivilegedContainer, "privileged", false, "Starts the container in privileged mode")
 	cmd.Flags().BoolVar(&Help, "help", false, "help for start")
 
@@ -59,7 +65,6 @@ func startNano(cmd *cobra.Command, args []string) {
 		startContainer(ContainerName)
 	} else {
 		pullImage()
-		fmt.Println("Running cluster " + ContainerNameToShow + "...")
 		runContainer(cmd, args)
 	}
 	echoInfo(ContainerName)
@@ -68,6 +73,7 @@ func startNano(cmd *cobra.Command, args []string) {
 // runContainer creates a new container when nothing exists
 func runContainer(cmd *cobra.Command, args []string) {
 	ContainerName := ContainerNamePrefix + args[0]
+	ContainerNameToShow := ContainerName[len(ContainerNamePrefix):]
 	RgwPort := generateRGWPortToUse()
 	if RgwPort == "notfound" {
 		log.Fatal("Unable to find a port between 8000 and 8100.")
@@ -93,11 +99,104 @@ func runContainer(cmd *cobra.Command, args []string) {
 		"CEPH_DEMO_UID=" + CephNanoUID,
 		"NETWORK_AUTO_DETECT=4",
 		"CEPH_DAEMON=demo",
-		"DEMO_DAEMONS=mon,mgr,osd,rgw"}
+		"DEMO_DAEMONS=mon,mgr,osd,rgw",
+	}
+
+	volumeBindings := []string{
+		WorkingDirectory + ":" + TempPath,
+	}
 
 	ressources := container.Resources{
 		Memory:   536870912, // 512MB
 		NanoCPUs: 1,
+	}
+
+	volumes := map[string]struct{}{
+		"/etc/ceph":     struct{}{},
+		"/var/lib/ceph": struct{}{},
+	}
+
+	if len(Data) != 0 {
+		testDev, err := GetFileType(Data)
+		if err != nil {
+			log.Fatal(err)
+		}
+		if testDev != "blockdev" && testDev != "directory" {
+			log.Fatalf("We only accept a directory or a block device, however the specified file type is a %s", testDev)
+		}
+		if testDev == "directory" {
+			testEmptyDir := IsEmpty(Data)
+			if !testEmptyDir {
+				log.Fatal(Data + " is not empty, doing nothing.")
+			}
+			envs = append(envs, "OSD_PATH="+Data)
+			volumeBindings = append(volumeBindings, Data+":"+Data)
+		}
+		if testDev == "blockdev" {
+			meUserName, meID := whoAmI()
+			if meID != "0" {
+				log.Fatal("Hey " + meUserName + "! Run me as 'root' when using a block device.")
+			}
+			// We don't have the logic to do the introspection without using blkid.
+			// Unfortunately, blkid is not available on macOS or Windows
+			if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
+				log.Fatal("Operating system: " + runtime.GOOS + " is not supported in the scenario")
+			}
+			// We run a couple of test here to ensure the device can be used:
+			// 1. test of the device is accessed by a process (open it with O_EXCL)
+			// 2. test if the device has a partition table and/or a filesystem
+			// 3. test if they are partitions in that partition table (you can have a partition table with 0 partitions)
+
+			// First test: is the device opened by a process?!«
+			testDevOpen, _ := ExclusiveOpenFailsOnDevice(Data)
+			if testDevOpen {
+				log.Fatal(Data + " is accessed by another process, doing nothing.")
+			}
+
+			// Second test: search for filesystem and partition table
+			diskFormat := GetDiskFormat(Data)
+			lines := strings.Split(diskFormat, "\n")
+			var fstype, pttype string
+			for _, l := range lines {
+				if len(l) <= 0 {
+					// Ignore empty line.
+					continue
+				}
+				cs := strings.Split(l, "=")
+				if len(cs) != 2 {
+					log.Fatal("blkid returns invalid output: " + diskFormat + ". This potentially means no partition label on your disk.")
+				}
+				// TYPE is filesystem type, and PTTYPE is partition table type, according
+				// to https://www.kernel.org/pub/linux/utils/util-linux/v2.21/libblkid-docs/.
+				if cs[0] == "TYPE" {
+					fstype = cs[1]
+					log.Fatal(Data + " has a filesystem: " + fstype + ", doing nothing.")
+				} else if cs[0] == "PTTYPE" {
+					// Third test: number of partitions
+					pttype = cs[1]
+					// Now we test if the disk has partition(s)
+					// We know parted will return 2 lines if there is a partition table:
+					//
+					// BYT;
+					// /dev/sdc:100GB:scsi:512:512:gpt:HP LOGICAL VOLUME:;
+					//
+					// So we remove the first 2 lines of the output
+					// The third one is always the partition number
+					partedUselessLinesCount := 2
+					num := GetDiskPartitions(Data)
+					partCount := len(num) - partedUselessLinesCount
+					if partCount != 0 {
+						log.Fatal(Data + " has a partition table type " + pttype + " and " + strconv.Itoa(partCount) + " partition(s) doing nothing.")
+					}
+				}
+			}
+			// If we arrive here, it should be safe to use the device.
+			envs = append(envs, "OSD_DEVICE="+Data)
+			PrivilegedContainer = true
+			volumeBindings = append(volumeBindings, "/dev:/dev")
+			// place holder once 'demo' will use ceph-volume
+			// volumeBindings = append(volumeBindings, "/run/lvm/lvmetad.socket:/run/lvm/lvmetad.socket")
+		}
 	}
 
 	config := &container.Config{
@@ -105,18 +204,17 @@ func runContainer(cmd *cobra.Command, args []string) {
 		Hostname:     ContainerName + "-faa32aebf00b",
 		ExposedPorts: exposedPorts,
 		Env:          envs,
-		Volumes: map[string]struct{}{
-			"/etc/ceph":     struct{}{},
-			"/var/lib/ceph": struct{}{},
-		},
+		Volumes:      volumes,
 	}
 
 	hostConfig := &container.HostConfig{
 		PortBindings: portBindings,
-		Binds:        []string{WorkingDirectory + ":" + TempPath},
+		Binds:        volumeBindings,
 		Resources:    ressources,
 		Privileged:   PrivilegedContainer,
 	}
+
+	fmt.Println("Running cluster " + ContainerNameToShow + "...")
 
 	resp, err := getDocker().ContainerCreate(ctx, config, hostConfig, nil, ContainerName)
 	if err != nil {

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -129,6 +129,9 @@ func runContainer(cmd *cobra.Command, args []string) {
 			if !testEmptyDir {
 				log.Fatal(Data + " is not empty, doing nothing.")
 			}
+			if runtime.GOOS == "linux" {
+				ApplySeLinuxLabel(Data)
+			}
 			envs = append(envs, "OSD_PATH="+Data)
 			volumeBindings = append(volumeBindings, Data+":"+Data)
 		}


### PR DESCRIPTION
You can now use a dedicated block device or a directy to store your
data. Using a block device will likely give you better performance where
a directory might your data more exposure but depending on your setup
might also give you better performance.

To start with a dedicated block device do:

sudo cn start cluster mycluster -b /dev/sdb

For a directory do:

cn start mycluster -b /srv/ceph

This block device mode is intended to work only on Linux only at the
moment since cn relies on utilies like 'blkid' and 'parted' to
instrospect the device. We have to verify the device is usable by
checking several things:
  * device is not accessed/open by a process
  * no partition table on the device
  * no partitions on that partition table
Also running cn under root is mandatory to execute blkid and parted
properly.

Just like the block device scenario running under root is required to
start ONLY if selinux is enabled. We have to apply selinux rules on the
directory so it can be accessed and written by the container.
While purging a cluster that was deployed on a directory is recommended
to call sudo.

Closes: #25
Signed-off-by: Sébastien Han <seb@redhat.com>