### PR TITLE
s3: fix ls and la calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ Open your terminal and download the cn binary.
 macOS:
 
 ```bash
-curl -L https://github.com/ceph/cn/releases/download/v1.1.1/cn-v1.1.1-903c23f-darwin-amd64 -o cn && chmod +x cn
+curl -L https://github.com/ceph/cn/releases/download/v1.4.0/cn-v1.4.0-334876b-darwin-amd64 -o cn && chmod +x cn
 ```
 
 Linux:
 
 ```bash
-curl -L https://github.com/ceph/cn/releases/download/v1.1.1/cn-v1.1.1-903c23f-linux-amd64 -o cn && chmod +x cn
+curl -L https://github.com/ceph/cn/releases/download/v1.4.0/cn-v1.4.0-334876b-linux-amd64 -o cn && chmod +x cn
 ```
 
 Test it out
@@ -56,7 +56,7 @@ Available Commands:
   cluster     Interact with a particular Ceph cluster
   s3          Interact with a particular S3 object server
   image       Interact with cn's container image(s)
-  version     Print cn's version number
+  version     Print the version of cn
   help        Help about any command
 
 Flags:
@@ -77,7 +77,6 @@ This operation can take a few minutes...........................................
 
 HEALTH_OK is the Ceph status
 S3 object server address is: http://192.168.0.10:8000
-S3 user is: nano
 S3 access key is: E7MCNPWED4BIV21J1BZG
 S3 secret key is: JG5wmxw2bGOxXLc7v6NQ2yg50atPCu3Nxe4XXvEf
 Your working directory is: /tmp

--- a/cmd/s3_la.go
+++ b/cmd/s3_la.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -26,13 +25,14 @@ func S3CmdLa(cmd *cobra.Command, args []string) {
 
 	notExistCheck(containerName)
 	notRunningCheck(containerName)
+
 	command := []string{"s3cmd", "la"}
-	output := strings.TrimSuffix(string(execContainer(containerName, command)), "\n") + " on cluster " + containerName
+	output := string(execContainer(containerName, command))
+
 	if len(output) == 1 {
 		command := []string{"s3cmd", "ls"}
-		output := strings.TrimSuffix(string(execContainer(containerName, command)), "\n") + " on cluster " + containerName
-		fmt.Println(output)
-	} else {
-		fmt.Println(output)
+		output := execContainer(containerName, command)
+		fmt.Printf("%s", output)
 	}
+	fmt.Printf("%s", output)
 }

--- a/cmd/s3_ls.go
+++ b/cmd/s3_ls.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -10,9 +9,9 @@ import (
 // cliS3CmdLs is the Cobra CLI call
 func cliS3CmdLs() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "ls CLUSTER BUCKET",
+		Use:   "ls CLUSTER [BUCKET]",
 		Short: "List objects or buckets",
-		Args:  cobra.ExactArgs(2),
+		Args:  cobra.RangeArgs(1, 2),
 		Run:   S3CmdLs,
 	}
 
@@ -25,7 +24,14 @@ func S3CmdLs(cmd *cobra.Command, args []string) {
 
 	notExistCheck(containerName)
 	notRunningCheck(containerName)
-	command := []string{"s3cmd", "ls", "s3://" + args[1]}
-	output := strings.TrimSuffix(string(execContainer(containerName, command)), "\n") + " on cluster " + containerName
-	fmt.Println(output)
+
+	var command []string
+
+	if len(args) == 1 {
+		command = []string{"s3cmd", "ls"}
+	} else {
+		command = []string{"s3cmd", "ls", "s3://" + args[1]}
+	}
+	output := execContainer(containerName, command)
+	fmt.Printf("%s", output)
 }

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -418,7 +418,7 @@ func inspectImage(ImageID string, dataType string) string {
 func pullImage() bool {
 	_, _, err := getDocker().ImageInspectWithRaw(ctx, imageName)
 	if err != nil {
-		fmt.Print("The container image is not present, pulling it. \n" +
+		fmt.Println("The container image is not present, pulling it. \n" +
 			"This operation can take a few minutes.")
 
 		out, err := getDocker().ImagePull(ctx, imageName, types.ImagePullOptions{})

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -323,7 +323,6 @@ func echoInfo(containerName string) {
 	infoLine :=
 		"\n" + strings.TrimSpace(string(c)) + " is the Ceph status \n" +
 			"S3 object server address is: http://" + ips[0].String() + ":" + rgwPort + "\n" +
-			"S3 user is: nano \n" +
 			"S3 access key is: " + cephNanoAccessKey + "\n" +
 			"S3 secret key is: " + cephNanoSecretKey + "\n" +
 			"Your working directory is: " + dir + "\n"

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -10,7 +10,7 @@ import (
 func cliVersionNano() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "version",
-		Short: "Print cn's version number",
+		Short: "Print the version of cn",
 		Args:  cobra.NoArgs,
 		Run:   versionNano,
 	}


### PR DESCRIPTION
Prior to this commit the output was incorrect and also the message "on
cluster $cluster" wasn't approprieate so I removed it.

Now 'ls' can receive a single argument only in order to list all the
buckets if empty where 'la' will continue to report all the objects in
all the buckets.

Signed-off-by: Sébastien Han <seb@redhat.com>