### PR TITLE
update-check: add new command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ prepare:
 	go get github.com/jmoiron/jsonq
 	go get github.com/apcera/termtables
 	go get golang.org/x/sys/unix
+	go get github.com/elgs/gojq
 
 darwin:
 	make GOOS=darwin GOARCH:=amd64

--- a/README.md
+++ b/README.md
@@ -53,12 +53,13 @@ Usage:
   cn [command]
 
 Available Commands:
-  cluster     Interact with a particular Ceph cluster
-  s3          Interact with a particular S3 object server
-  image       Interact with cn's container image(s)
-  version     Print the version of cn
-  kube        Outputs cn kubernetes template (cn kube > kube-cn.yml)
-  help        Help about any command
+  cluster      Interact with a particular Ceph cluster
+  s3           Interact with a particular S3 object server
+  image        Interact with cn's container image(s)
+  version      Print the version of cn
+  kube         Outputs cn kubernetes template (cn kube > kube-cn.yml)
+  update-check Print cn current and latest version number
+  help         Help about any command
 
 Flags:
   -h, --help   help for cn

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -31,9 +31,10 @@ const (
                  /(((.  /(((((  /(((((
                         .((((/ (/
 `
-	cephNanoUID         = "nano"       // cephNanoUID is the uid of the S3 user
-	containerNamePrefix = "ceph-nano-" // containerNamePrefix is name of the container
-	tempPath            = "/tmp/"      // tempPath is the temporary path inside the container
+	cephNanoUID         = "nano"                                          // cephNanoUID is the uid of the S3 user
+	containerNamePrefix = "ceph-nano-"                                    // containerNamePrefix is name of the container
+	tempPath            = "/tmp/"                                         // tempPath is the temporary path inside the container
+	githubCNReleasesURL = "https://api.github.com/repos/ceph/cn/releases" // githubCNReleasesURL is the GitHub URL of cn releases
 )
 
 var (
@@ -114,6 +115,7 @@ func init() {
 		cmdImage,
 		cliVersionNano(),
 		cliKubeNano(),
+		cliUpdateCheckNano(),
 	)
 }
 

--- a/cmd/update-check.go
+++ b/cmd/update-check.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/elgs/gojq"
+	"github.com/spf13/cobra"
+)
+
+// cliUpdateCheckNano is the Cobra CLI call
+func cliUpdateCheckNano() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "update-check",
+		Short: "Print cn current and latest version number",
+		Args:  cobra.NoArgs,
+		Run:   updateCheckNano,
+	}
+
+	return cmd
+}
+
+// updateCheckNano print Ceph Nano version
+func updateCheckNano(cmd *cobra.Command, args []string) {
+	url := githubCNReleasesURL
+	output := curlURL(url)
+
+	parser, err := gojq.NewStringQuery(string(output))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	latestTag, err := parser.Query("[0].tag_name")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	cnVersionSplit := strings.Fields(cnVersion)
+	cnVersionNum := cnVersionSplit[0]
+
+	fmt.Println("Current version:", cnVersionNum)
+	fmt.Println("Latest version:", latestTag)
+
+	if latestTag != cnVersionNum {
+		latestTagURL, err := parser.Query("[0].html_url")
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Println("There is a newer version of cn available. Download it here:", latestTagURL)
+	}
+}

--- a/tests/functional-tests.sh
+++ b/tests/functional-tests.sh
@@ -195,6 +195,12 @@ function test_version {
   reportSuccess
 }
 
+function test_update_check {
+  start_test
+  runCn update-check
+  reportSuccess
+}
+
 function test_s3_mb {
   start_test
   runCn s3 mb "$current_cluster_name" $bucket
@@ -461,7 +467,7 @@ function main() {
       $cli_test
     done
   else
-    for test in version image_update logs restart status stop start version image_update image_list status logs; do
+    for test in version update_check image_update logs restart status stop start version image_update image_list status logs; do
       test_$test
     done
 


### PR DESCRIPTION
cn has now a new command that will help you find out if there is a new
version available of cn.

Run it like this: cn update-check

Closes: https://github.com/ceph/cn/issues/55
Signed-off-by: Sébastien Han <seb@redhat.com>