### PR TITLE
README: update links in installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ Open your terminal and download the cn binary.
 macOS:
 
 ```bash
-curl -L https://github.com/ceph/cn/releases/download/v1.5.0/cn-v1.5.0-8fa7a91-darwin-amd64 -o cn && chmod +x cn
+curl -L https://github.com/ceph/cn/releases/download/v1.6.1/cn-v1.6.1-b900468-darwin-amd64 -o cn && chmod +x cn
 ```
 
 Linux:
 
 ```bash
-curl -L https://github.com/ceph/cn/releases/download/v1.5.0/cn-v1.5.0-8fa7a91-linux-amd64 -o cn && chmod +x cn
+curl -L https://github.com/ceph/cn/releases/download/v1.6.1/cn-v1.6.1-b900468-linux-amd64 -o cn && chmod +x cn
 ```
 
 Test it out


### PR DESCRIPTION
Update the link in installation section of README to v1.6.1

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>