### PR TITLE
update-check: Don't fail if API rate limit is exceeded

### DIFF
--- a/cmd/update-check.go
+++ b/cmd/update-check.go
@@ -31,6 +31,13 @@ func updateCheckNano(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 
+	message, err := parser.Query("message")
+	// if a message exists in the answer, let's print it and return
+	if err == nil {
+		fmt.Println(message)
+		return
+	}
+
 	latestTag, err := parser.Query("[0].tag_name")
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
When running many PRs on travis, we sometimes reach the API rate limit like in :
    API rate limit exceeded for w.x.y.z (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)

This patch simply check if a message is present in the answer, if so,
let's print it and return.

update-check is not really critical so it's acceptable just reporting the github message instead of failing.

Signed-off-by: Erwan Velu <erwan@redhat.com>