### PR TITLE
purge: Split container name from message string

### DIFF
--- a/cmd/purge.go
+++ b/cmd/purge.go
@@ -87,7 +87,7 @@ func removeContainer(containerName string) {
 			Force:         true,
 			PruneChildren: true,
 		}
-		log.Println("Removing container image" + imageName + "...")
+		log.Println("Removing container image " + imageName + "...")
 		getDocker().ImageRemove(ctx, imageName, options)
 	}
 }


### PR DESCRIPTION
The actual code was gluing both information message and container name leading to a wrong output.

A typical output was like :
    Purging cluster term...
    Removing container image978c3e793c58...

This patch simply add a space before the container name.

Signed-off-by: Erwan Velu <erwan@redhat.com>