### PR TITLE
travis: do not unshallow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ branches:
 
 before_install:
   - docker --version
-  - git fetch --unshallow
 
 jobs:
   include:


### PR DESCRIPTION
--unshallow on a complete repository does not make sense since travis
has 'depth' disabled.

Signed-off-by: Sébastien Han <seb@redhat.com>