### PR TITLE
contrib: remove vendor folder

### DIFF
--- a/contrib/release.sh
+++ b/contrib/release.sh
@@ -161,6 +161,8 @@ fi
 
 echo "Building binaries for git tag $TAG"
 make clean-all
+make prepare
+rm -rf "$GOPATH"/src/github.com/docker/docker/vendor/github.com/docker/go-connections/nat
 make -s release TAG="$TAG" || fatal "Cannot build ceph-nano !"
 
 rm cn || fatal "Cannot remove cn"

--- a/contrib/travis.sh
+++ b/contrib/travis.sh
@@ -30,8 +30,7 @@ function commit_changed_readme {
 
 function compile_cn {
     make prepare
-    mv "$GOPATH"/src/github.com/docker/docker/vendor/github.com/docker/go-connections/nat "$GOPATH"/src/github.com/docker/docker/vendor/github.com/docker/go-connections/nonat
-    make
+    rm -rf "$GOPATH"/src/github.com/docker/docker/vendor/github.com/docker/go-connections/nat
     sudo ./cn version
 }
 


### PR DESCRIPTION
If we don't do this we will have this error:

cmd/start.go:12:2: cannot find package "github.com/docker/go-connections/nat" in any of:
	/home/travis/.gimme/versions/go1.9.7.linux.amd64/src/github.com/docker/go-connections/nat (from $GOROOT)
	/home/travis/gopath/src/github.com/docker/go-connections/nat (from $GOPATH)

Signed-off-by: Sébastien Han <seb@redhat.com>