### PR TITLE
release: Enforcing build branch for travis builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 VERSION = $(shell git describe --always --long --dirty)
 TAG = devel
-BRANCH = $(shell git rev-parse --abbrev-ref HEAD)
+TARGET_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
 
 # Variables to choose cross-compile target
 GOOS:=linux
@@ -10,7 +10,7 @@ GOARCH:=amd64
 CN_EXTENSION:=
 
 build: check clean prepare
-	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -i -ldflags="-X main.version=$(VERSION) -X main.tag=$(TAG) -X main.branch=$(BRANCH)" -o cn-$(TAG)-$(VERSION)-$(GOOS)-$(GOARCH)$(CN_EXTENSION) main.go
+	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -i -ldflags="-X main.version=$(VERSION) -X main.tag=$(TAG) -X main.branch=$(TARGET_BRANCH)" -o cn-$(TAG)-$(VERSION)-$(GOOS)-$(GOARCH)$(CN_EXTENSION) main.go
 	ln -sf "cn-$(TAG)-$(VERSION)-$(GOOS)-$(GOARCH)$(CN_EXTENSION)" cn$(CN_EXTENSION)
 
 check:

--- a/contrib/release.sh
+++ b/contrib/release.sh
@@ -60,6 +60,7 @@ usage() {
   -g <token>    : github token (can be defined with GITHUB_TOKEN variable)
   -t <tag>      : tag to be released (can be defined with TAG variable)
   -p <tag>      : previous tag to make the CHANGELOG (can be defined with PTAG variable)
+  -b <branch>   : force the branch name to be included in the build
 EOF
   exit 2
 }
@@ -84,11 +85,14 @@ if ! command -v github-release &>/dev/null; then
   isBinaryExists github-release
 fi
 
-optspec=":hg:p:t:"
+optspec=":hg:p:t:b:"
 while getopts "$optspec" optchar; do
   case "${optchar}" in
     h)
       usage
+      ;;
+    b)
+      export TARGET_BRANCH=${OPTARG}
       ;;
     g)
       export GITHUB_TOKEN=${OPTARG}

--- a/contrib/travis.sh
+++ b/contrib/travis.sh
@@ -52,7 +52,7 @@ fi
 if [[ "$1" == "tag-release" ]]; then
     if [ -n "$TRAVIS_TAG" ]; then
         echo "I'm running on tag $TRAVIS_TAG, let's build a new release!"
-        ./contrib/release.sh -g "$GITHUB_TOKEN" -t "$TRAVIS_TAG" -p "$PENULTIMATE_TAG"
+        ./contrib/release.sh -g "$GITHUB_TOKEN" -t "$TRAVIS_TAG" -p "$PENULTIMATE_TAG" -b "master"
         git checkout master
         edit_readme
         commit_changed_readme


### PR DESCRIPTION
When travis is building, it does it on a detached head making the final binary to be tracked as build on HEAD.
This patch is about enforcing the branch name in such case only.

Signed-off-by: Erwan Velu <erwan@redhat.com>