### PR TITLE
image: print image name also

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,18 +120,20 @@ $ ./cn cluster ls
 
 ## List Ceph container images available
 
-`cn` can list the available Ceph container image tag available:
+`cn` can list the available Ceph container images, the default output shows the 100 first images:
 
 ```bash
 $ ./cn image ls
-latest
-master-a104cb7-jewel-ubuntu-16.04-x86_64
-master-a104cb7-kraken-ubuntu-16.04-x86_64
-master-a104cb7-jewel-ubuntu-14.04-x86_64
-master-a104cb7-kraken-centos-7-x86_64
-master-a104cb7-luminous-centos-7-x86_64
-master-a104cb7-luminous-ubuntu-16.04-x86_64
-master-a104cb7-jewel-centos-7-x86_64
-master-5f44af9-kraken-ubuntu-16.04-x86_64
-master-5f44af9-kraken-centos-7-x86_64
+ceph/daemon:master-a104cb7-jewel-ubuntu-16.04-x86_64
+ceph/daemon:master-a104cb7-kraken-ubuntu-16.04-x86_64
+ceph/daemon:master-a104cb7-jewel-ubuntu-14.04-x86_64
+ceph/daemon:master-a104cb7-kraken-centos-7-x86_64
+ceph/daemon:master-a104cb7-luminous-centos-7-x86_64
+ceph/daemon:master-a104cb7-luminous-ubuntu-16.04-x86_64
+ceph/daemon:master-a104cb7-jewel-centos-7-x86_64
+ceph/daemon:master-5f44af9-kraken-ubuntu-16.04-x86_64
+ceph/daemon:master-5f44af9-kraken-centos-7-x86_64
+...
+...
+...
 ```

--- a/README.md
+++ b/README.md
@@ -17,25 +17,25 @@ Open your terminal and download the cn binary.
 
 macOS:
 
-```bash
+```
 curl -L https://github.com/ceph/cn/releases/download/v1.9.0/cn-v1.9.0-0883cac-darwin-amd64 -o cn && chmod +x cn
 ```
 
 Linux amd64:
 
-```bash
+```
 curl -L https://github.com/ceph/cn/releases/download/v1.9.0/cn-v1.9.0-0883cac-linux-amd64 -o cn && chmod +x cn
 ```
 
 Linux arm64:
 
-```bash
+```
 curl -L https://github.com/ceph/cn/releases/download/v1.9.0/cn-v1.9.0-0883cac-linux-arm64 -o cn && chmod +x cn
 ```
 
 Test it out
 
-```bash
+```
 $ ./cn
 Ceph Nano - One step S3 in container with Ceph.
 
@@ -77,7 +77,7 @@ Use "cn [command] --help" for more information about a command.
 
 Start the program with a working directory `/tmp`, the initial start might take a few minutes since we need to download the container image:
 
-```bash
+```
 $ ./cn cluster start -d /tmp my-first-cluster
 Running ceph-nano...
 The container image is not present, pulling it.
@@ -95,7 +95,7 @@ Ceph Nano browser address is: http://10.36.116.164:5001
 
 Create a bucket with `cn`:
 
-```bash
+```
 $ ./cn s3 mb my-first-cluster my-buc
 Bucket 's3://my-buc/' created
 
@@ -108,7 +108,7 @@ upload: '/tmp/passwd' -> 's3://my-buc/passwd'  [1 of 1]
 
 `cn` can manage any number of clusters on your local machine:
 
-```bash
+```
 $ ./cn cluster ls
 +------+---------+-------------------------------------------------------------------------------------+----------------+--------------------------------+
 | NAME | STATUS  | IMAGE                                                                               | IMAGE RELEASE  | IMAGE CREATION TIME            |
@@ -122,7 +122,7 @@ $ ./cn cluster ls
 
 `cn` can list the available Ceph container images, the default output shows the 100 first images:
 
-```bash
+```
 $ ./cn image ls
 ceph/daemon:master-a104cb7-jewel-ubuntu-16.04-x86_64
 ceph/daemon:master-a104cb7-kraken-ubuntu-16.04-x86_64

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -250,13 +250,14 @@ func pageCount() int {
 // parseMap parses a json element
 // re-adapted code from:
 // https://stackoverflow.com/questions/29366038/looping-iterate-over-the-second-level-nested-json-in-go-lang
-func parseMap(aMap map[string]interface{}, keyType string) {
+func parseMap(aMap map[string]interface{}, keyType string, image string) {
 	for key, val := range aMap {
 		switch concreteVal := val.(type) {
 		case []interface{}:
-			parseArray(val.([]interface{}), keyType)
+			parseArray(val.([]interface{}), keyType, image)
 		default:
 			if key == keyType {
+				fmt.Print(image)
 				fmt.Println(concreteVal)
 			}
 		}
@@ -266,12 +267,13 @@ func parseMap(aMap map[string]interface{}, keyType string) {
 // parseArray parses json array
 // re-adapted code from:
 // https://stackoverflow.com/questions/29366038/looping-iterate-over-the-second-level-nested-json-in-go-lang
-func parseArray(anArray []interface{}, keyType string) {
+func parseArray(anArray []interface{}, keyType string, image string) {
 	for _, val := range anArray {
 		switch concreteVal := val.(type) {
 		case map[string]interface{}:
-			parseMap(val.(map[string]interface{}), keyType)
+			parseMap(val.(map[string]interface{}), keyType, image)
 		default:
+			fmt.Print(image)
 			fmt.Println(concreteVal)
 		}
 	}
@@ -803,7 +805,7 @@ func listDockerRegistryImageTags() {
 		if err != nil {
 			log.Fatal(err)
 		}
-		parseMap(m, "name")
+		parseMap(m, "name", "ceph/daemon:")
 	}
 }
 
@@ -819,5 +821,5 @@ func listRedHatRegistryImageTags() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	parseMap(m, "tags")
+	parseMap(m, "tags", "rhceph-3-rhel7:")
 }


### PR DESCRIPTION
Do not only print the image tag but the complete name so users can
simply copy it and then run:

'cn cluster start -i <image>'

Signed-off-by: Sébastien Han <seb@redhat.com>