### PR TITLE
enter: new call to get inside a container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ prepare:
 	go get github.com/apcera/termtables
 	go get golang.org/x/sys/unix
 	go get github.com/elgs/gojq
+	go get golang.org/x/crypto/ssh/terminal
 
 darwin:
 	make GOOS=darwin GOARCH:=amd64

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Available Commands:
   version      Print the version of cn
   kube         Outputs cn kubernetes template (cn kube > kube-cn.yml)
   update-check Print cn current and latest version number
+  enter        Connect inside a given cluster
 
 Flags:
   -h, --help   help for cn

--- a/cmd/enter.go
+++ b/cmd/enter.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func cliEnterNano() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "enter [cluster]",
+		Short: "Connect inside a given cluster",
+		Args:  cobra.ExactArgs(1),
+		Run:   enterNano,
+		DisableFlagsInUseLine: true,
+	}
+
+	return cmd
+}
+
+func enterNano(cmd *cobra.Command, args []string) {
+	containerNameToShow := args[0]
+	containerName := containerNamePrefix + containerNameToShow
+
+	notExistCheck(containerName)
+	enterContainer(containerName)
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -115,6 +115,7 @@ func init() {
 		cliVersionNano(),
 		cliKubeNano(),
 		cliUpdateCheckNano(),
+		cliEnterNano(),
 	)
 	rootCmd.SetHelpCommand(&cobra.Command{
 		Use:    "no-help",


### PR DESCRIPTION
You can now use 'enter' call to connect inside the container and get
access to the ceph cluster.

cn cluster enter <cluster name>

Signed-off-by: Sébastien Han <seb@redhat.com>