### PR TITLE
enter: place enter under the cluster section

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ Available Commands:
   version      Print the version of cn
   kube         Outputs cn kubernetes template (cn kube > kube-cn.yml)
   update-check Print cn current and latest version number
-  enter        Connect inside a given cluster
 
 Flags:
   -h, --help   help for cn

--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -21,5 +21,6 @@ func init() {
 		cliClusterRestart(),
 		cliClusterLogs(),
 		cliClusterPurge(),
+		cliEnterNano(),
 	)
 }

--- a/cmd/enter.go
+++ b/cmd/enter.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// cliEnterNano is the Cobra CLI call
 func cliEnterNano() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "enter [cluster]",
@@ -16,6 +17,7 @@ func cliEnterNano() *cobra.Command {
 	return cmd
 }
 
+// enterNano enters inside a container
 func enterNano(cmd *cobra.Command, args []string) {
 	containerNameToShow := args[0]
 	containerName := containerNamePrefix + containerNameToShow

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -115,7 +115,6 @@ func init() {
 		cliVersionNano(),
 		cliKubeNano(),
 		cliUpdateCheckNano(),
-		cliEnterNano(),
 	)
 	rootCmd.SetHelpCommand(&cobra.Command{
 		Use:    "no-help",


### PR DESCRIPTION
It makes more sense to have the new 'enter' call as part of the cluster
section.

Signed-off-by: Sébastien Han <seb@redhat.com>