### PR TITLE
contrib: %install failed at installing files

### DIFF
--- a/contrib/cn.spec
+++ b/contrib/cn.spec
@@ -44,8 +44,8 @@ export LDFLAGS="$LDFLAGS -X main.version=%{source_version}"
 
 %install
 install -D -p -m 755 bin/cn %{buildroot}%{_bindir}/cn
-install -D -p -m 644 cn.toml %{buildroot}%{_sysconfdir}/cn/
-install -D -p -m 644 contrib/cn_completion.sh %{buildroot}%{_sysconfdir}/bash_completion.d/
+install -D -p -m 644 cn.toml %{buildroot}%{_sysconfdir}/cn/cn.toml
+install -D -p -m 644 contrib/cn_completion.sh %{buildroot}%{_sysconfdir}/bash_completion.d/cn_completion.sh
 
 %files
 %doc README.md


### PR DESCRIPTION
The last argument of install must be a filename and not a directory.
That was making the specfile failing at %install time.

Signed-off-by: Erwan Velu <erwan@redhat.com>