### PR TITLE
adds update notification for newer version of nano

### DIFF
--- a/cmd/config_file.go
+++ b/cmd/config_file.go
@@ -45,6 +45,9 @@ const LATESTIMAGE = DEFAULTIMAGE + ":latest-"
 // DEFAULTWORKDIRECTORY is the default work directory
 const DEFAULTWORKDIRECTORY = "/usr/share/ceph-nano"
 
+// UPDATE is a constant to represent the [update] group
+const UPDATE = "update"
+
 func readConfigFile(customFile ...string) string {
 	// By default, we consider there is no configuration file
 	var configurationFile string
@@ -114,6 +117,10 @@ func setDefaultConfig() {
 	viper.SetDefault(IMAGES+".mimic.image_name", LATESTIMAGE+"mimic")
 	viper.SetDefault(IMAGES+".luminous.image_name", LATESTIMAGE+"luminous")
 	viper.SetDefault(IMAGES+".redhat.image_name", "registry.access.redhat.com/rhceph/rhceph-3-rhel7")
+
+	// Setting up the default update notification configuration
+	viper.SetDefault(UPDATE+".config.want_update_notification", true)
+	viper.SetDefault(UPDATE+".config.reminder_wait_period_in_hours", 24)
 }
 
 func getStringFromConfig(group string, item string, name string) string {
@@ -240,4 +247,20 @@ func mergeFlavorsWithDefault() {
 			}
 		}
 	}
+}
+
+func getFloat64FromConfig(group string, item string, name string) float64 {
+	var value float64
+	var foundValue = false
+
+	// We need to ensure the key exists unless that could populate a 0 value
+	if isParameterExist(group, item, name) {
+		value = viper.GetFloat64(group + "." + item + "." + name)
+		foundValue = true
+	}
+
+	if !foundValue {
+		log.Fatal(name + " float64 value in " + item + " doesn't exist")
+	}
+	return value
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -69,6 +69,8 @@ var (
 	// configurationFile is the name of the used configuration file
 	configurationFile = ""
 
+	enableUpdateNotification = true
+
 	rootCmd = &cobra.Command{
 		Use:        cliName,
 		Short:      cliDescription,
@@ -125,7 +127,9 @@ func getDocker() *client.Client {
 // Main is the main function calling the whole program
 func Main(version string) {
 	cnVersion = version
-
+	if enableUpdateNotification {
+		checkUpdateNotification()
+	}
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/cmd/notify.go
+++ b/cmd/notify.go
@@ -1,0 +1,69 @@
+/*
+ * Ceph Nano (C) 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Below main package has canonical imports for 'go get' and 'go build'
+ * to work with all other clones of github.com/ceph/cn repository. For
+ * more information refer https://golang.org/doc/go1.4#canonicalimports
+ */
+
+package cmd
+
+import (
+	"io/ioutil"
+	"log"
+	"time"
+)
+
+var (
+	timeLayout              = time.RFC1123
+	lastUpdateCheckFilePath = makeCephNanoPath("last_update_check")
+)
+
+func checkUpdateNotification() {
+	if !shouldCheckURLVersion(lastUpdateCheckFilePath) {
+		return
+	}
+	updateCheckNano(nil, nil)
+	writeTimeToFile(lastUpdateCheckFilePath, time.Now().UTC())
+}
+
+func shouldCheckURLVersion(filePath string) bool {
+	if !getBoolFromConfig("update", "config", "want_update_notification") {
+		return false
+	}
+	lastUpdateTime := getTimeFromFileIfExists(filePath)
+	return time.Since(lastUpdateTime).Hours() >= getFloat64FromConfig("update", "config", "reminder_wait_period_in_hours")
+}
+
+func writeTimeToFile(path string, inputTime time.Time) {
+	err := ioutil.WriteFile(path, []byte(inputTime.Format(timeLayout)), 0644)
+	if err != nil {
+		log.Fatalf("Error writing current update time to file: %v", err)
+	}
+}
+
+func getTimeFromFileIfExists(path string) time.Time {
+	lastUpdateCheckTime, err := ioutil.ReadFile(path)
+	if err != nil {
+		return time.Time{}
+	}
+	timeInFile, err := time.Parse(timeLayout, string(lastUpdateCheckTime))
+	if err != nil {
+		return time.Time{}
+	}
+	return timeInFile
+}

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -48,6 +48,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/elgs/gojq"
 	"github.com/jmoiron/jsonq"
+	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/viper"
 	"golang.org/x/crypto/ssh/terminal"
 	"golang.org/x/sys/unix"
@@ -945,4 +946,25 @@ func getWorkDirectory(containerFlavor string) string {
 
 func setWorkDirectory(value string) {
 	workingDirectory = value
+}
+
+// makeCephNanoPath is a utility to calculate a relative path to .cn directory.
+func makeCephNanoPath(fileName ...string) string {
+	args := []string{getCephNanoPath()}
+	args = append(args, fileName...)
+	return filepath.Join(args...)
+}
+
+// getCephNanoPath returns the path to the user's .cn directory
+func getCephNanoPath() string {
+	homeDirPath, err := homedir.Dir()
+	if err != nil {
+		log.Fatal(err)
+	}
+	// check if the .cn directory exists else create the directory
+	cephNanoPath := filepath.Join(homeDirPath, ".cn")
+	if _, err := os.Stat(cephNanoPath); os.IsNotExist(err) {
+		os.Mkdir(cephNanoPath, os.FileMode(int(0775)))
+	}
+	return cephNanoPath
 }

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -1,0 +1,61 @@
+/*
+ * Ceph Nano (C) 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Below main package has canonical imports for 'go get' and 'go build'
+ * to work with all other clones of github.com/ceph/cn repository. For
+ * more information refer https://golang.org/doc/go1.4#canonicalimports
+ */
+
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mitchellh/go-homedir"
+	"github.com/stretchr/testify/assert"
+)
+
+func patchEnvVar(key, value string) func() {
+	bck := os.Getenv(key)
+	deferFunc := func() {
+		os.Setenv(key, bck)
+	}
+	if value != "" {
+		os.Setenv(key, value)
+	} else {
+		os.Unsetenv(key)
+	}
+	return deferFunc
+}
+
+func TestGetCephNanoPath(t *testing.T) {
+	homedir.DisableCache = true
+	defer func() { homedir.DisableCache = false }()
+	defer patchEnvVar("HOME", "/custom/path/")()
+	expected := filepath.Join("/", "custom", "path", ".cn")
+	assert.Equal(t, expected, getCephNanoPath())
+}
+
+func TestMakeCephNanoPath(t *testing.T) {
+	homedir.DisableCache = true
+	defer func() { homedir.DisableCache = false }()
+	defer patchEnvVar("HOME", "/custom/path/")()
+	expected := filepath.Join("/", "custom", "path", ".cn", "test_last_update_check")
+	assert.Equal(t, expected, makeCephNanoPath("test_last_update_check"))
+}


### PR DESCRIPTION
This commit
-creates a new directory .cn in the user's home directory, which contains last_update_check file that records the time of the last update notification.
-adds update notification related configurations i.e, want_update_notification by default set to true and reminder_wait_period_in_hours by default set to 24 to the cn configuration file.
-adds notify.go that contains logic for triggering notification.
-modifies config_file.go, main.go, utils.go

Fixes: #43 
Signed-off-by: Deepika Joshi <djoshi@redhat.com>