### PR TITLE
start & kube: add RGW_FRONTEND_PORT variable

### DIFF
--- a/cmd/kube.go
+++ b/cmd/kube.go
@@ -132,6 +132,9 @@ metadata:
   	    	env:
   	    	- name: NETWORK_AUTO_DETECT
   	    	  value: "4"
+		- name: RGW_FRONTEND_PORT
+                  value: "8000"
+                # Keep this for backward compatiblity, the option is gone since https://github.com/ceph/ceph-container/pull/1356
   	    	- name: RGW_CIVETWEB_PORT
   	    	  value: "8000"
   	    	- name: SREE_PORT

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -147,8 +147,9 @@ func runContainer(cmd *cobra.Command, args []string) {
 	ips, _ := getInterfaceIPv4s()
 
 	envs := []string{
-		"RGW_CIVETWEB_PORT=" + rgwPort, // DON'T TOUCH MY POSITION IN THE SLICE OR YOU WILL BREAK dockerInspect()
+		"RGW_FRONTEND_PORT=" + rgwPort, // DON'T TOUCH MY POSITION IN THE SLICE OR YOU WILL BREAK dockerInspect()
 		"SREE_PORT=" + cnBrowserPort,   // DON'T TOUCH MY POSITION IN THE SLICE OR YOU WILL BREAK dockerInspect()
+		"RGW_CIVETWEB_PORT=" + rgwPort, // Keep this for backward compatiblity, the option is gone since https://github.com/ceph/ceph-container/pull/1356
 		"EXPOSED_IP=" + ips[0].String(),
 		"DEBUG=verbose",
 		"CEPH_DEMO_UID=" + cephNanoUID,


### PR DESCRIPTION
This commit
- adds RGW_FRONTEND_PORT to the list of environment variables in start.go and kube.go.

Since the PR ceph/ceph-container#1356, the RGW_CIVETWEB_PORT option has been dropped; we retain it for compatibility with the older versions.

Fixes: #117, #116, #115 
Signed-off-by: Deepika Joshi <djoshi@redhat.com>