### PR TITLE
cmd/utils: Fix pagination on image list

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -54,6 +54,8 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+const pageSize int = 100
+
 // byLastOctetValue implements sort.Interface used in sorting a list
 // of ip address by their last octet value.
 type byLastOctetValue []net.IP
@@ -295,7 +297,11 @@ func countTags() int {
 
 func pageCount() int {
 	tagCount := countTags()
-	pageCount := tagCount / 10
+	pageCount := tagCount / pageSize
+	remainder := tagCount % pageSize
+	if remainder > 0 {
+		pageCount++
+	}
 	return int(pageCount)
 }
 
@@ -829,7 +835,7 @@ func listDockerRegistryImageTags() {
 
 	for i := 1; i <= numPage; i++ {
 		// convert numPage into a string for concatenation, (see the end)
-		url = "https://registry.hub.docker.com/v2/repositories/ceph/daemon/tags/?page_size=100&page=" + strconv.Itoa(i)
+		url = "https://registry.hub.docker.com/v2/repositories/ceph/daemon/tags/?page_size=" + strconv.Itoa(pageSize) + "&page=" + strconv.Itoa(i)
 		output := curlURL(url)
 
 		// Parsing/Unmarshalling JSON encoding/json


### PR DESCRIPTION
The current page count value is using the tag count divided by 10. But
we are using a page size value of 100.
That means we're iterate 10x more than we should do.
Also we should add an extra page when the remainder of the modulo
operation between the tag count and page size isn't zero.

With:
  tagCount = 1937
  pageSize = 100
Then:
  pageCount = 20

Because there's 19 pages with 100 results and 1 page with 37 results.

Adding the pageSize as a constant.

$ cn image ls -a
before : ~ 22 seconds
 after : ~  6 seconds

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>