### PR TITLE
Dependency apcera/termtables does not exist anymore

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -7,6 +7,7 @@
 [[constraint]]
   branch = "master"
   name = "github.com/apcera/termtables"
+  source = "github.com/brettski/go-termtables"
 
 [[override]]
  name = "github.com/docker/distribution"


### PR DESCRIPTION
Others have had the same problem, and moved to a copy of the repository
at https://github.com/brettski/go-termtables

This just modifies the `Gopkg.toml` to fetch the package from a different
source. Of course it would be possible to change the import of the package
instead. Not sure if that has the preference.